### PR TITLE
Capture CPU/memory usage at beginning of profiling session

### DIFF
--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/PostStopOptions.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Contracts/PostStopOptions.cs
@@ -16,6 +16,8 @@ internal class PostStopOptions
         Uri stampFrontendHostUrl,
         IEnumerable<SampleActivity> samples,
         IProfilerSource profilerSource,
+        float averageCPUUsage,
+        float averageMemoryUsage,
         string? uploaderFullPath = null)
     {
         if (string.IsNullOrEmpty(traceFilePath))
@@ -28,6 +30,8 @@ internal class PostStopOptions
         StampFrontendHostUrl = stampFrontendHostUrl;
         Samples = samples ?? throw new ArgumentNullException(nameof(samples));
         ProfilerSource = profilerSource ?? throw new ArgumentNullException(nameof(profilerSource));
+        AverageCPUUsage = averageCPUUsage;
+        AverageMemoryUsage = averageMemoryUsage;
         UploaderFullPath = uploaderFullPath;
     }
 
@@ -35,6 +39,16 @@ internal class PostStopOptions
     public DateTimeOffset SessionId { get; }
     public Uri StampFrontendHostUrl { get; }
     public IProfilerSource ProfilerSource { get; }
+
+    /// <summary>
+    /// Average CPU usage captured at the beginning of the profiling session.
+    /// </summary>
+    public float AverageCPUUsage { get; }
+
+    /// <summary>
+    /// Average memory usage captured at the beginning of the profiling session.
+    /// </summary>
+    public float AverageMemoryUsage { get; }
 
     public string? UploaderFullPath { get; set; }
     public IEnumerable<SampleActivity> Samples { get; set; }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/ICustomEventsBuilder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services.Abstractions/ICustomEventsBuilder.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ApplicationInsights.Profiler.Shared.Services.Abstractions;
 
 internal interface ICustomEventsBuilder
 {
-    ServiceProfilerIndex CreateServiceProfilerIndex(string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource);
+    ServiceProfilerIndex CreateServiceProfilerIndex(string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource, float averageCPUUsage, float averageMemoryUsage);
 
     IEnumerable<ServiceProfilerSample> CreateServiceProfilerSamples(IReadOnlyCollection<SampleActivity> samples, string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId);
 }

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/CustomEventsBuilder.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/CustomEventsBuilder.cs
@@ -20,7 +20,6 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
     private readonly IServiceProfilerContext _serviceProfilerContext;
     private readonly IRoleNameSource _roleNameSource;
     private readonly IRoleInstanceSource _roleInstanceSource;
-    private readonly IResourceUsageSource _resourceUsageSource;
     private readonly ILogger _logger;
     private string? _roleNameCache;
     private string? _roleInstanceCache;
@@ -29,17 +28,15 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
         IServiceProfilerContext serviceProfilerContext,
         IRoleNameSource roleNameSource,
         IRoleInstanceSource roleInstanceSource,
-        IResourceUsageSource resourceUsageSource,
         ILogger<CustomEventsBuilder> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
         _roleNameSource = roleNameSource ?? throw new ArgumentNullException(nameof(roleNameSource));
         _roleInstanceSource = roleInstanceSource ?? throw new ArgumentNullException(nameof(roleInstanceSource));
-        _resourceUsageSource = resourceUsageSource ?? throw new ArgumentNullException(nameof(resourceUsageSource));
     }
 
-    public ServiceProfilerIndex CreateServiceProfilerIndex(string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource)
+    public ServiceProfilerIndex CreateServiceProfilerIndex(string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource, float averageCPUUsage, float averageMemoryUsage)
     {
         ServiceProfilerIndex result = new()
         {
@@ -53,8 +50,8 @@ internal class CustomEventsBuilder : ICustomEventsBuilder
             ProgrammingLanguage = ProgramLanguages.CSharp,
             Source = profilerSource.Source,
             OperatingSystem = Environment.OSVersion.VersionString,
-            AverageCPUUsage = _resourceUsageSource.GetAverageCPUUsage(),
-            AverageMemoryUsage = _resourceUsageSource.GetAverageMemoryUsage(),
+            AverageCPUUsage = averageCPUUsage,
+            AverageMemoryUsage = averageMemoryUsage,
             CloudRoleName = _roleNameCache ??= _roleNameSource.CloudRoleName
         };
 

--- a/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
+++ b/src/Microsoft.ApplicationInsights.Profiler.Shared/Services/PostStopProcessor.cs
@@ -154,7 +154,7 @@ internal class PostStopProcessor : IPostStopProcessor
 
                 // Contract with Upload, sending additional data
                 Guid artifactId = ArtifactIdDerivation.DeriveArtifactId(e.SessionId, _serviceProfilerContext.MachineName);
-                IPCAdditionalData additionalData = CreateAdditionalData(e.Samples.ToImmutableArray(), stampId: "%StampId%", e.SessionId, appId, artifactId, e.ProfilerSource);
+                IPCAdditionalData additionalData = CreateAdditionalData(e.Samples.ToImmutableArray(), stampId: "%StampId%", e.SessionId, appId, artifactId, e.ProfilerSource, e.AverageCPUUsage, e.AverageMemoryUsage);
                 if (_logger.IsEnabled(LogLevel.Trace))
                 {
                     _logger.LogTrace("Sending additional data for the uploader to use.");
@@ -201,7 +201,8 @@ internal class PostStopProcessor : IPostStopProcessor
 
     private IPCAdditionalData CreateAdditionalData(
         IReadOnlyCollection<SampleActivity> samples,
-        string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource)
+        string stampId, DateTimeOffset sessionId, Guid appId, Guid artifactId, IProfilerSource profilerSource,
+        float averageCPUUsage, float averageMemoryUsage)
         => new()
         {
             ConnectionString = _serviceProfilerContext.ConnectionString?.ToString(),
@@ -211,7 +212,9 @@ internal class PostStopProcessor : IPostStopProcessor
                 sessionId: sessionId,
                 appId: appId,
                 artifactId: artifactId,
-                profilerSource: profilerSource),
+                profilerSource: profilerSource,
+                averageCPUUsage: averageCPUUsage,
+                averageMemoryUsage: averageMemoryUsage),
             ServiceProfilerSamples = _customEventsBuilder.CreateServiceProfilerSamples(
                 samples: samples,
                 stampId: stampId,

--- a/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe.Otel/Azure.Monitor.OpenTelemetry.Profiler.Core/OpenTelemetryProfilerProvider.cs
@@ -14,12 +14,15 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 {
     internal const string TraceFileExtension = ".nettrace";
     private string? _currentTraceFilePath;
+    private float _sessionCPUUsage;
+    private float _sessionMemoryUsage;
     private readonly SemaphoreSlim _singleProfilingSemaphore = new(1, 1);
     private readonly ITraceControl _traceControl;
     private readonly IUserCacheManager _userCacheManager;
     private readonly TraceSessionListenerFactory _traceSessionListenerFactory;
     private readonly IPostStopProcessorFactory _postStopProcessorFactory;
     private readonly IServiceProfilerContext _serviceProfilerContext;
+    private readonly IResourceUsageSource _resourceUsageSource;
     private readonly ILogger<OpenTelemetryProfilerProvider> _logger;
 
     private const string StartProfilerTriggered = "StartProfiler triggered.";
@@ -39,12 +42,14 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
         TraceSessionListenerFactory traceSessionListenerFactory,
         IPostStopProcessorFactory postStopProcessorFactory,
         IServiceProfilerContext serviceProfilerContext,
+        IResourceUsageSource resourceUsageSource,
         ILogger<OpenTelemetryProfilerProvider> logger)
     {
         _userCacheManager = userCacheManager ?? throw new ArgumentNullException(nameof(userCacheManager));
         _traceSessionListenerFactory = traceSessionListenerFactory ?? throw new ArgumentNullException(nameof(traceSessionListenerFactory));
         _postStopProcessorFactory = postStopProcessorFactory ?? throw new ArgumentNullException(nameof(postStopProcessorFactory));
         _serviceProfilerContext = serviceProfilerContext ?? throw new ArgumentNullException(nameof(serviceProfilerContext));
+        _resourceUsageSource = resourceUsageSource ?? throw new ArgumentNullException(nameof(resourceUsageSource));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _traceControl = traceControl ?? throw new ArgumentNullException(nameof(traceControl));
     }
@@ -82,6 +87,11 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
         try
         {
+            // Capture resource usage at the beginning of the profiling session, before trace collection starts.
+            _sessionCPUUsage = _resourceUsageSource.GetAverageCPUUsage();
+            _sessionMemoryUsage = _resourceUsageSource.GetAverageMemoryUsage();
+            _logger.LogDebug("Captured resource usage at session start: CPU={cpuUsage}, Memory={memoryUsage}", _sessionCPUUsage, _sessionMemoryUsage);
+
             _logger.LogDebug("Call TraceControl.Enable().");
             await _traceControl.EnableAsync(_currentTraceFilePath, cancellationToken).ConfigureAwait(false);
 
@@ -138,6 +148,11 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
 
         try
         {
+            // Copy resource usage values captured at session start before releasing the semaphore,
+            // to avoid a race where a new session could overwrite these fields.
+            float cpuUsage = _sessionCPUUsage;
+            float memoryUsage = _sessionMemoryUsage;
+
             // Notice: Stop trace session listener has to be happen before calling ITraceControl.Disable().
             // Trace control disabling will take a while. We shall not gathering anything events when disable is happening.
             _logger.LogDebug("Disabling {sessionListener}", nameof(_listener));
@@ -155,7 +170,9 @@ internal sealed class OpenTelemetryProfilerProvider : IServiceProfilerProvider, 
                 currentSessionId.Value,
                 stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
                 sampleActivities ?? Enumerable.Empty<SampleActivity>(),
-                source), cancellationToken).ConfigureAwait(false);
+                source,
+                averageCPUUsage: cpuUsage,
+                averageMemoryUsage: memoryUsage), cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(StopProfilerSucceeded);
 

--- a/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
+++ b/src/ServiceProfiler.EventPipe/ServiceProfiler.EventPipe.Client/ServiceProfilerProvider.cs
@@ -34,6 +34,10 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
     private readonly IServiceProfilerContext _serviceProfilerContext;
     private readonly ITraceControl _traceControl;
     private readonly IEventPipeTelemetryTracker _telemetryTracker;
+    private readonly IResourceUsageSource _resourceUsageSource;
+
+    private float _sessionCPUUsage;
+    private float _sessionMemoryUsage;
 
     private IEnumerator<ITraceSessionListener>? _sessionListeners;
     internal ITraceSessionListener? SessionListener { get; private set; }
@@ -60,6 +64,7 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
         IPostStopProcessorFactory postStopProcessorFactory,
         ITraceFileFormatDefinition traceFileFormatDefinition,
         AppInsightsProfileFetcher appInsightsProfileFetcher,
+        IResourceUsageSource resourceUsageSource,
         ILogger<ServiceProfilerProvider> logger)
     {
         // Required
@@ -75,6 +80,7 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
         _traceSessionListenerFactory = traceSessionListenerFactory ?? throw new ArgumentNullException(nameof(traceSessionListenerFactory));
         _telemetryTracker = telemetryTracker ?? throw new ArgumentNullException(nameof(telemetryTracker));
         _appInsightsSinks = appInsightsSinks ?? throw new ArgumentNullException(nameof(appInsightsSinks));
+        _resourceUsageSource = resourceUsageSource ?? throw new ArgumentNullException(nameof(resourceUsageSource));
     }
 
     /// <summary>
@@ -113,6 +119,11 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
             try
             {
+                // Capture resource usage at the beginning of the profiling session, before trace collection starts.
+                _sessionCPUUsage = _resourceUsageSource.GetAverageCPUUsage();
+                _sessionMemoryUsage = _resourceUsageSource.GetAverageMemoryUsage();
+                _logger.LogDebug("Captured resource usage at session start: CPU={cpuUsage}, Memory={memoryUsage}", _sessionCPUUsage, _sessionMemoryUsage);
+
                 _logger.LogDebug("Call TraceControl.Enable().");
                 await _traceControl.EnableAsync(_currentTraceFilePath, cancellationToken).ConfigureAwait(false);
                 profilerStarted = true;
@@ -182,6 +193,11 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
 
         try
         {
+            // Copy resource usage values captured at session start before releasing the semaphore,
+            // to avoid a race where a new session could overwrite these fields.
+            float cpuUsage = _sessionCPUUsage;
+            float memoryUsage = _sessionMemoryUsage;
+
             // Notice: Stop trace session listener has to be happen before calling ITraceControl.Disable().
             // Trace control disabling will take a while. We shall not gathering anything events when disable is happening.
             _logger.LogDebug("Disabling {sessionListener}", nameof(SessionListener));
@@ -201,7 +217,9 @@ internal sealed class ServiceProfilerProvider : IServiceProfilerProvider, IDispo
                     currentSessionId.Value,
                     stampFrontendHostUrl: _serviceProfilerContext.StampFrontendEndpointUrl,
                     sampleActivities ?? Enumerable.Empty<SampleActivity>(),
-                    source
+                    source,
+                    averageCPUUsage: cpuUsage,
+                    averageMemoryUsage: memoryUsage
                     ), cancellationToken).ConfigureAwait(false);
 
                 _appInsightsSinks.LogInformation(profilerStopped ? StopProfilerSucceeded : StopProfilerFailed);


### PR DESCRIPTION
## Summary

Fixes https://github.com/Azure/azuremonitor-opentelemetry-profiler-net/issues/56

Previously, average CPU and memory usage were captured at the **end** of the profiling session (during post-stop processing in \CustomEventsBuilder.CreateServiceProfilerIndex\). This fix moves the capture to the **beginning** of the session — before trace collection starts — in both the OTel and classic profiler providers.

## Changes

- **\PostStopOptions\** — Added immutable \AverageCPUUsage\ and \AverageMemoryUsage\ properties (constructor params)
- **\OpenTelemetryProfilerProvider\** — Injects \IResourceUsageSource\, captures usage before \EnableAsync\, passes via \PostStopOptions\
- **\ServiceProfilerProvider\** (classic) — Same pattern as OTel provider
- **\ICustomEventsBuilder\** — Updated \CreateServiceProfilerIndex\ to accept CPU/memory as parameters
- **\CustomEventsBuilder\** — Uses passed-in values; removed \IResourceUsageSource\ dependency (no longer needed here)
- **\PostStopProcessor\** — Forwards values from \PostStopOptions\ to \CreateServiceProfilerIndex\

## Thread Safety

Captured values are stored in provider fields while the single-profiling semaphore is held, and copied to locals in \StopServiceProfilerAsync\ before the semaphore is released — preventing a race where a new session could overwrite the values.

## Testing

- Both solutions build with 0 errors
- All 108 tests pass (21 OTel + 29 classic profiler + 58 client tests)
- Code reviewed by GPT 5.5 and Opus 4.7 (2 consecutive clear rounds each)